### PR TITLE
feat: add kali gpg key setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Lint shell script
+        run: bash -n install.sh
+      - name: Test Kali key installation
+        run: ./tests/kali_key_test.sh

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This script automates the installation of [Katoolin3](https://github.com/s-h-3-l
 ## **What It Does**
 - Updates and upgrades the system.
 - Installs required dependencies (`git`, `python3`, `python3-apt`, etc.).
+- Adds the official Kali Linux repository signing key.
 - Clones the Katoolin3 repository.
 - Runs the installation.
 - Configures Katoolin3 to run globally.

--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,10 @@ apt update && apt upgrade -y
 echo "[*] Installing dependencies..."
 apt install -y git python3 python3-apt wget apt-transport-https software-properties-common
 
+# Add Kali Linux GPG key
+echo "[*] Adding Kali Linux repository key..."
+wget -q -O - https://archive.kali.org/archive-key.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/kali-archive-keyring.gpg >/dev/null
+
 # Clone Katoolin3 Repository
 echo "[*] Cloning the Katoolin3 GitHub repository..."
 if [[ -d "katoolin3" ]]; then

--- a/tests/kali_key_test.sh
+++ b/tests/kali_key_test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+wget -q -O - https://archive.kali.org/archive-key.asc | gpg --dearmor | tee "$TMPDIR/kali-archive-keyring.gpg" >/dev/null
+test -s "$TMPDIR/kali-archive-keyring.gpg"


### PR DESCRIPTION
## Summary
- add step to install Kali Linux archive key during installation
- document key installation in README
- run simple test for key download and wire into CI

## Testing
- `bash -n install.sh`
- `./tests/kali_key_test.sh` *(fails: Proxy tunneling failed: Forbidden)*


fixes #1 